### PR TITLE
Small typo in command-line-only-laptop.md

### DIFF
--- a/content/post/2021/02/command-line-only-laptop.md
+++ b/content/post/2021/02/command-line-only-laptop.md
@@ -221,6 +221,6 @@ There's fun things you can do on the command line including games like [Dwarf Fo
 
 ![AAA](/blog/images/2021-02-09/aaa.png)
 
-## Conclusion
+## Conclusion=
 
-While this is really just a bit of fun, there's a tremendous amount of productive work you can get done on the command line only Linux system in 2021. Have a look around, discover some old and new applications, and maybe save some CPU cylces and RAM here and there along the way, or just have some fun playing. 
+While this is really just a bit of fun, there's a tremendous amount of productive work you can get done on the command line only Linux system in 2021. Have a look around, discover some old and new applications, and maybe save some CPU cycles and RAM here and there along the way, or just have some fun playing.

--- a/content/post/2021/02/command-line-only-laptop.md
+++ b/content/post/2021/02/command-line-only-laptop.md
@@ -221,6 +221,6 @@ There's fun things you can do on the command line including games like [Dwarf Fo
 
 ![AAA](/blog/images/2021-02-09/aaa.png)
 
-## Conclusion=
+## Conclusion
 
 While this is really just a bit of fun, there's a tremendous amount of productive work you can get done on the command line only Linux system in 2021. Have a look around, discover some old and new applications, and maybe save some CPU cycles and RAM here and there along the way, or just have some fun playing.


### PR DESCRIPTION
Don't blame me for adding blank line at the end of the file. Also removed trailing white space at the end of problematic line.

Thanks to M86xKC on Ubuntu Podcast Telegram chat for [finding that typo _(link only available for people who actually joined that chat)_](https://t.me/c/1045945811/360375)