### PR TITLE
Update snap-tips.md

### DIFF
--- a/content/post/2020/12/snap-tips.md
+++ b/content/post/2020/12/snap-tips.md
@@ -496,7 +496,7 @@ This is fun. Setup a cron job as the `root` user which runs every day, pushing b
 
 `0 12 * * * /usr/bin/snap set system refresh.hold="$(/usr/bin/date --iso-8601=seconds -d '+30 days')"`
 
-**Note**: `snapd` is [hard-wired](https://github.com/snapcore/snapd/blob/master/overlord/snapstate/autorefresh.go#L45) to ignore this, and update after 60 days. 
+**Note**: `snapd` is [hard-wired](https://github.com/snapcore/snapd/blob/master/overlord/snapstate/autorefresh.go#L45) to ignore this, and update after 95 days. 
 
 ### Set refresh time
 


### PR DESCRIPTION
Per [9a86a22](https://github.com/snapcore/snapd/commit/9a86a2269e920a497830e38bb65c4f356d7d9c4d), snapd now waits 95 days before forcing a refresh.