### PR TITLE
Update Hugo version to 0.156.0 to match Cloudflare

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.118.2'
+          hugo-version: '0.156.0'
           extended: false
 
       - name: Build Website


### PR DESCRIPTION
## Summary
- Updated Hugo version in GitHub Actions workflow from 0.118.2 to 0.156.0
- Fixes build failure caused by `.Site.Lastmod` not existing in older Hugo versions
- Aligns the CI Hugo version with the Cloudflare deployment

## Test plan
- [ ] Verify the GitHub Actions workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)